### PR TITLE
Fix error in migration

### DIFF
--- a/backend/database/migrations/2020_05_09_120622_create_lessons_table.php
+++ b/backend/database/migrations/2020_05_09_120622_create_lessons_table.php
@@ -20,7 +20,7 @@ class CreateLessonsTable extends Migration
             $table->string('file');
             $table->string('file_ext');
             $table->integer('order');
-            $table->integer('course_id')->unsigned()->index();
+            $table->biginteger('course_id')->unsigned()->index();
             $table->timestamps();
 
             $table->foreign('course_id')->references('id')->on('courses');


### PR DESCRIPTION
Fixes this error:

```
$ php artisan migrate:fresh --seed
Dropped all tables successfully.
Migration table created successfully.
Migrating: 2014_10_12_000000_create_users_table
Migrated:  2014_10_12_000000_create_users_table (0.08 seconds)
Migrating: 2014_10_12_100000_create_password_resets_table
Migrated:  2014_10_12_100000_create_password_resets_table (0.07 seconds)
Migrating: 2019_08_19_000000_create_failed_jobs_table
Migrated:  2019_08_19_000000_create_failed_jobs_table (0.01 seconds)
Migrating: 2019_12_14_000001_create_personal_access_tokens_table
Migrated:  2019_12_14_000001_create_personal_access_tokens_table (0.04 seconds)
Migrating: 2020_05_01_121713_create_courses_table
Migrated:  2020_05_01_121713_create_courses_table (0.07 seconds)
Migrating: 2020_05_09_120622_create_lessons_table

   Illuminate\Database\QueryException 

  SQLSTATE[HY000]: General error: 3780 Referencing column 'course_id' and referenced column 'id' in foreign key constraint 'lessons_course_id_foreign' are incompatible. (SQL: alter table `lessons` add constraint `lessons_course_id_foreign` foreign key (`course_id`) references `courses` (`id`))

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:671
    667|         // If an exception occurs when attempting to run a query, we'll format the error
    668|         // message to include the bindings with SQL, which will make this exception a
    669|         // lot more helpful to the developer instead of just the database's errors.
    670|         catch (Exception $e) {
  > 671|             throw new QueryException(
    672|                 $query, $this->prepareBindings($bindings), $e
    673|             );
    674|         }
    675| 

      +9 vendor frames 
  10  database/migrations/2020_05_09_120622_create_lessons_table.php:27
      Illuminate\Support\Facades\Facade::__callStatic("create")

      +34 vendor frames 
  45  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))

```